### PR TITLE
Fix javac path escaping for wildcard in cmake.

### DIFF
--- a/apps/Java/CMakeLists.txt
+++ b/apps/Java/CMakeLists.txt
@@ -18,7 +18,7 @@ macro(ut_get_customized_app_creator)
 		           POST_BUILD
 		           COMMAND cmake -E echo "Compiling Java files..."
 		           COMMAND cmake -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/classes/ubitrack
-		           COMMAND ${Java_JAVAC_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/gensrc/ubitrack/*.java -d ${CMAKE_CURRENT_BINARY_DIR}/classes
+		           COMMAND ${Java_JAVAC_EXECUTABLE} \"${CMAKE_CURRENT_BINARY_DIR}/gensrc/ubitrack/\"*.java -d ${CMAKE_CURRENT_BINARY_DIR}/classes
 		           COMMAND cmake -E echo "Creating jar file..."
 		           COMMAND ${Java_JAR_EXECUTABLE} cvf ubitrack.jar -C ${CMAKE_CURRENT_BINARY_DIR}/classes ubitrack 
 	)


### PR DESCRIPTION
When CMAKE_CURRENT_BINARY_DIR contains spaces, the quotes are placed around the "*.java" wildcard passed as the input files to javac. Some versions of javac cannot deal with this and can only deal with * when not in quotes. This leads to a compilation failure of `ubitrack_java`.

This change forces the quotes to only be around the directory section of the path and not the wildcard.